### PR TITLE
Container may not have a class

### DIFF
--- a/core/jquery.shapeshift.coffee
+++ b/core/jquery.shapeshift.coffee
@@ -745,7 +745,7 @@
   $.fn[pluginName] = (options) ->
     @each ->
       # Destroy any old resize events
-      old_class = $(@).attr("class").match(/shapeshifted_container_\w+/)?[0]
+      old_class = $(@).attr("class")?.match(/shapeshifted_container_\w+/)?[0]
       if old_class
         bound_indentifier = "resize." + old_class
         $(window).off(bound_indentifier)


### PR DESCRIPTION
Plugin should not barf if container does not have a class.
