### PR TITLE
Determine the active children on render

### DIFF
--- a/core/jquery.shapeshift.coffee
+++ b/core/jquery.shapeshift.coffee
@@ -220,6 +220,7 @@
     # arrange them to the calculated grid
     # ----------------------------
     render: (reparse = false, trigger_drop_finished) ->
+      @setActiveChildren() if reparse
       @setGridColumns()
       @arrange(reparse, trigger_drop_finished)
 


### PR DESCRIPTION
If I apply _shapeshift_ to a container with children, then remove some of its children and add new ones, and trigger a `ss-rearrange` on the container, I expect the new children to be shapeshifted correctly.

However, triggering `ss-rearrange` calls render, which currently does not recalculate the children of the container, so the new nodes are not taken into account.

My solution involves calling `setActiveChildren` on render if `reparse` is `true`, which activates and parses new children, and makes everything work, but I'd like to hear your opinion on the performance implications of this.
