### PR TITLE
Remove unnecessary reparse

### DIFF
--- a/core/jquery.shapeshift.coffee
+++ b/core/jquery.shapeshift.coffee
@@ -222,7 +222,7 @@
     render: (reparse = false, trigger_drop_finished) ->
       @setActiveChildren() if reparse
       @setGridColumns()
-      @arrange(reparse, trigger_drop_finished)
+      @arrange(false, trigger_drop_finished)
 
     # ----------------------------
     # setGrid:


### PR DESCRIPTION
Calling `setActiveChildren` already calls `setParsedChildren`, so it's not necessary to call it again inside `arrange`.
