### PR TITLE
Makeshift vertical alignment

### DIFF
--- a/core/jquery.shapeshift.js
+++ b/core/jquery.shapeshift.js
@@ -365,13 +365,44 @@
         (determinePositions = function() {
           var child, _j, _results;
           _results = [];
+          
+          
+           // Create an array of the # of items than need to go in
+           // each column vertically
+           // (ex: [3, 2, 2] if 7 items going in 3 columns)
+           var floor = Math.floor( total_children / globals.columns );
+           var mod = total_children % globals.columns;
+           var arr = [], item_comparator = 0, col_in_order = 0;
+           for (var x = 0; x < globals.columns; x++) {
+              var y = floor;
+              if (x+1 <= mod) y++;
+              arr.push(y);
+           }
+           // Get the first column's required number of items
+           // less 1 for zero-based item index used in the following
+           // for loop
+           item_comparator = arr[col_in_order] - 1;
+          
+          
           for (i = _j = 0; 0 <= total_children ? _j < total_children : _j > total_children; i = 0 <= total_children ? ++_j : --_j) {
             child = parsed_children[i];
             if (!(!include_dragged && child.el.hasClass(dragged_class))) {
               if (child.colspan > 1) {
                 child.col = determineMultiposition(child);
               } else {
-                child.col = _this.lowestCol(col_heights);
+                
+                // When the current item being placed is in
+                // the next column, refresh the comparator by
+                // adding the next column's required # of items
+                if ( item_comparator == i - 1 ) {
+                   col_in_order++;
+                   item_comparator += arr[col_in_order];
+                }
+                 
+                // Place the item in the lower index column (to the left)
+                // based on the default lowestCol or by order as calculated above
+                child.col = Math.min(_this.lowestCol(col_heights), col_in_order);
+                
               }
               if (child.col === void 0) {
                 saved_children.push(child);


### PR DESCRIPTION
Hello,
Thanks for the great plugin, it is the best solution I have found for my layout. I recently commented on this issue: https://github.com/McPants/jquery.shapeshift/issues/80

I have made some modifications to the code in order to implement vertical flow of items; please have a look. I realized after my modifications that I made these changes to the master branch instead of the 3.0, so if you like I can do that, although I am sure you will be able to better optimize than me. I also don't understand the plugin well enough so please suggest improvements as you wish (ex: to isolate this behavior into an option).

Here are a few screenshots to demonstrate the behavior. Note that in some cases (for example the 3 column layout that the third panel went to the first column even though it is better fit in terms of room in the second column -- I do not know how to fix this, so suggestions are welcome)

4 columns:
![4-col](https://f.cloud.github.com/assets/6564897/2059966/bf350746-8bed-11e3-8f56-b259786f6873.PNG)
3 columns:
![3-col](https://f.cloud.github.com/assets/6564897/2059967/bf41742c-8bed-11e3-858e-d6610a2ff68a.PNG)
2 columns:
![2-col](https://f.cloud.github.com/assets/6564897/2059968/bf44f96c-8bed-11e3-8df7-0ab484cc7acb.PNG)

Thanks again for a fantastic plugin
