### PR TITLE
Bugfix Rails compilation

### DIFF
--- a/core/jquery.shapeshift.coffee
+++ b/core/jquery.shapeshift.coffee
@@ -58,7 +58,7 @@
     constructor: (@element, options) ->
       @options = $.extend {}, defaults, options
       @globals = {}
-      @$container = $(element)
+      @$container = $(@element)
 
       if @errorCheck()
         @init()


### PR DESCRIPTION
When compiling inside a Rails project I get :

```
function Plugin(element1, options) {
        this.element = element1;
        this.options = $.extend({}, defaults, options);
        this.globals = {};
        this.$container = $(element);
        if (this.errorCheck()) {
          this.init();
        }
      }
```

and I always get an "element is not defined" error.